### PR TITLE
plugins: don't consume workspace file if it doesn't exist

### DIFF
--- a/data/plugins/wasm_workspace.lua
+++ b/data/plugins/wasm_workspace.lua
@@ -63,6 +63,7 @@ local function consume_workspace_file(project_dir)
       latest_id = id
     end
   end
+  if not latest_file then return end
   local load_f = loadfile(latest_file)
   local workspace = load_f and load_f()
   if workspace and workspace.path == project_dir then


### PR DESCRIPTION
`loadfile` with no parameters/`nil` tries to load from `stdin`, which results in `window.prompt` showing up in the browser.