### PR TITLE
ci: publish docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+build-emscripten-wasm32
+github-pages
+out

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,51 +12,65 @@ on:
           - true
           - false
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
-  build:
+  build-push-image-and-publish:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      packages: write
+      attestations: write
+      id-token: write
     steps:
-      # TODO: fix cache
-      - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v14
-        with:
-          version: 3.1.64
-          # actions-cache-folder: emsdk-cache
-
       - name: Checkout this repository
         uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
         with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: shell/package-lock.json
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - name: Get lowercase repository name
+        id: repo_name
+        uses: ASzc/change-string-case-action@v6
         with:
-            python-version: '3.x'
+          string: ${{ github.repository }}
 
-      - name: Install meson
-        run: pip install meson ninja
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ steps.repo_name.outputs.lowercase }}:latest
+          # Export both as a container image and in the out directory
+          outputs: |
+            type=docker
+            out
 
-      - name: Build
-        run: bash scripts/gh-pages-deploy.sh
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ steps.repo_name.outputs.lowercase }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Prepare pages artifact
+        run: tar --dereference --hard-dereference -cf github-pages.tar --directory out/dist .
 
       - name: Upload pages artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,7 +70,7 @@ jobs:
           push-to-registry: true
 
       - name: Prepare pages artifact
-        run: tar --dereference --hard-dereference -cf github-pages.tar --directory out/dist .
+        run: tar --dereference --hard-dereference -cf github-pages.tar --directory out/usr/share/nginx/html .
 
       - name: Upload pages artifact
         uses: actions/upload-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,16 +24,6 @@ RUN rm -rf build-emscripten-wasm32 github-pages && \
     source /etc/profile.d/emscripten.sh && \
     bash scripts/gh-pages-deploy.sh
 
-FROM node:current-alpine
+FROM nginx:latest
 
-WORKDIR /dist
-
-COPY --from=build /build/github-pages .
-
-RUN npm i -g http-server
-
-EXPOSE 8080
-
-ENV NODE_ENV=production
-
-ENTRYPOINT [ "npx", "http-server" ]
+COPY --from=build /build/github-pages /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM archlinux:base-devel AS build
+
+RUN pacman -Syu --noconfirm meson git emscripten jre-openjdk-headless unzip npm
+
+# Uncomment if you want emsdk
+# RUN useradd -m --shell=/bin/false build && \
+#     usermod -L build && \
+#     echo "build ALL= NOPASSWD: /usr/bin/pacman" > /etc/sudoers.d/build
+#
+# USER build
+#
+# WORKDIR /home/build
+#
+# RUN git clone https://aur.archlinux.org/emsdk.git && \
+#     cd emsdk && makepkg -sfi --noconfirm
+#
+# USER root
+
+WORKDIR /build
+
+COPY . .
+
+RUN rm -rf build-emscripten-wasm32 github-pages && \
+    source /etc/profile.d/emscripten.sh && \
+    bash scripts/gh-pages-deploy.sh
+
+FROM node:current-alpine
+
+WORKDIR /dist
+
+COPY --from=build /build/github-pages .
+
+RUN npm i -g http-server
+
+EXPOSE 8080
+
+ENV NODE_ENV=production
+
+ENTRYPOINT [ "npx", "http-server" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,16 @@
-FROM archlinux:base-devel AS build
+FROM emscripten/emsdk:latest AS build
 
-RUN pacman -Syu --noconfirm meson git emscripten jre-openjdk-headless unzip npm
+USER emscripten
 
-# Uncomment if you want emsdk
-# RUN useradd -m --shell=/bin/false build && \
-#     usermod -L build && \
-#     echo "build ALL= NOPASSWD: /usr/bin/pacman" > /etc/sudoers.d/build
-#
-# USER build
-#
-# WORKDIR /home/build
-#
-# RUN git clone https://aur.archlinux.org/emsdk.git && \
-#     cd emsdk && makepkg -sfi --noconfirm
-#
-# USER root
+ENV PATH="$PATH:/home/emscripten/.local/bin"
+
+RUN pip install meson ninja
 
 WORKDIR /build
 
-COPY . .
+COPY --chown=emscripten . .
 
-RUN rm -rf build-emscripten-wasm32 github-pages && \
-    source /etc/profile.d/emscripten.sh && \
-    bash scripts/gh-pages-deploy.sh
+RUN bash scripts/gh-pages-deploy.sh
 
 FROM nginx:latest
 

--- a/scripts/gh-pages-deploy.sh
+++ b/scripts/gh-pages-deploy.sh
@@ -26,7 +26,7 @@ if ! command -v file_packager >/dev/null 2>&1; then
 fi
 
 build_dir=$(get_default_build_dir "emscripten" "wasm32")
-dest_dir=lite-xl
+dest_dir=github-pages
 
 # install node deps
 if ! [[ -d shell/node_modules ]]; then
@@ -62,12 +62,3 @@ node shell/closure.js "${dest_dir}/lite-xl-files.min.js" "${dest_dir}/lite-xl-fi
 # these files can be removed for final distribution
 rm -rf "$(pwd)/${dest_dir}/lite-xl.js" "$(pwd)/${dest_dir}/lite-xl-files.js" \
         "${data_dir}" "$(pwd)/${dest_dir}/doc"
-
-package_name="github-pages"
-echo "Creating a compressed archive ${package_name}"
-
-tar \
-    --dereference --hard-dereference \
-    --directory "${dest_dir}" \
-    -cvf "$(pwd)/${package_name}.tar" \
-    .


### PR DESCRIPTION
This should publish a container image on ghcr.
At the moment this only pushes the tag `latest`. Should we add proper versions?
I'm using https://www.npmjs.com/package/http-server as entrypoint; is that ok, or should I look at using something else (nginx)?